### PR TITLE
fix: use transactionType 'IMMEDIATE' to prevent deadlocks

### DIFF
--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -44,7 +44,8 @@ class SequelizeMocking {
             storage: useFromFileDatabase ?
                 path.join(SequelizeMocking.getTempPath(namespace), 'database.sqlite') :
                 ':memory:',
-            dialect: 'sqlite'
+            dialect: 'sqlite',
+            transactionType: 'IMMEDIATE'
         };
 
         let optionsExtended = _.merge(

--- a/test/sequelize-mockingSpec.js
+++ b/test/sequelize-mockingSpec.js
@@ -102,7 +102,7 @@ describe('SequelizeMocking - ', function () {
                     'storage': ':memory:',
                     'sync': {},
                     'timezone': '+00:00',
-                    'transactionType': 'DEFERRED',
+                    'transactionType': 'IMMEDIATE',
                     'typeValidation': false
                 });
         });


### PR DESCRIPTION
When running multple tests that use transactions we might fails on SQLITE_BUSY: database is locked error. To prevent this I added transactionType: 'IMMEDIATE' to the mock sequelize options.

[More info](https://github.com/sequelize/sequelize/issues/10304)