### PR TITLE
feat: Clean temp folder

### DIFF
--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -111,6 +111,11 @@ class SequelizeMocking {
         return path.join('.sequelize-mocking-temp', namespace);
     }
 
+    static cleanTempFolder() {
+        const items = fs.readdirSync(SequelizeMocking.getTempPath());
+        items.forEach(item => fs.rmSync(SequelizeMocking.getTempPath(item), { recursive: true, force: true }));
+    }
+
     /**
      * @param {string} namespace
      */
@@ -183,6 +188,7 @@ class SequelizeMocking {
         if (useExistingBackup) {
             SequelizeMocking.restoreBackup(namespace);
         } else {
+            SequelizeMocking.cleanTempFolder();
             SequelizeMocking.createCleanFolder(namespace);
             const mockedSequelize = await SequelizeMocking.createAndLoadFixtureFile(originalSequelize, fixtureFilePath, clonedOptions, namespace);
             await mockedSequelize.close();

--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -111,9 +111,14 @@ class SequelizeMocking {
         return path.join('.sequelize-mocking-temp', namespace);
     }
 
+    /**
+     * Clean the temp folder from residual directories and files that may have been left over from previous runs that were not cleaned up.
+     */
     static cleanTempFolder() {
-        const items = fs.readdirSync(SequelizeMocking.getTempPath());
-        items.forEach(item => fs.rmSync(SequelizeMocking.getTempPath(item), { recursive: true, force: true }));
+        if (fs.existsSync(SequelizeMocking.getTempPath(''))) {
+            const items = fs.readdirSync(SequelizeMocking.getTempPath(''));
+            items.forEach(item => fs.rmSync(SequelizeMocking.getTempPath(item), { recursive: true, force: true }));
+        }
     }
 
     /**

--- a/lib/sequelize-mocking.js
+++ b/lib/sequelize-mocking.js
@@ -116,8 +116,8 @@ class SequelizeMocking {
      */
     static cleanTempFolder() {
         if (fs.existsSync(SequelizeMocking.getTempPath(''))) {
-            const items = fs.readdirSync(SequelizeMocking.getTempPath(''));
-            items.forEach(item => fs.rmSync(SequelizeMocking.getTempPath(item), { recursive: true, force: true }));
+            const oldNamespaces = fs.readdirSync(SequelizeMocking.getTempPath(''));
+            oldNamespaces.forEach(ns => fs.rmSync(SequelizeMocking.getTempPath(ns), { recursive: true, force: true }));
         }
     }
 


### PR DESCRIPTION
When the test suite is stopped mid run (e.g. with `ctrl+c`) the namespace folder and files are not cleaned up.

<img width="473" height="67" alt="Screenshot 2025-10-19 at 11 20 10" src="https://github.com/user-attachments/assets/23bb9b31-9c49-4586-9409-0fc2cf40d060" />

Added a method to delete any such residues on each test run.