### PR TITLE
feat: [PLM-8714] add Jest wrapper (sequelizeMockingJest)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,3 +19,9 @@ Object.defineProperty(module.exports, 'sequelizeMockingMocha', {
         return require('./lib/sequelize-mocking-mocha');
     }
 });
+
+Object.defineProperty(module.exports, 'sequelizeMockingJest', {
+    'get': function() {
+        return require('./lib/sequelize-mocking-jest');
+    }
+});

--- a/lib/sequelize-mocking-jest.js
+++ b/lib/sequelize-mocking-jest.js
@@ -1,0 +1,75 @@
+/**
+ * Using SequelizeMocking with Jest easily
+ *
+ * @module lib/sequelize-mocking-jest
+ * @exports sequelizeMockingJest
+ * @version 0.1.0
+ * @since 2.1.0
+ */
+
+// Imports
+const { v4: uuidv4 } = require('uuid');
+const SequelizeMocking = require('./sequelize-mocking');
+let truncatableSequelize = null;
+
+/**
+ * @name sequelizeMockingJest
+ * @param {Sequelize} originalSequelize
+ * @param {string | Array.<String>} [fixtureFilePath]
+ * @param {SequelizeMockingOptions} [options]
+ */
+module.exports = async function (originalSequelize, fixtureFilePath, options) {
+    if (options.initTruncatable) {
+        truncatableSequelize = await SequelizeMocking.createAndSync(originalSequelize, options);
+    } else if (originalSequelize.options.isTruncatable) {
+        let beforeEach = global.beforeEach ? global.beforeEach : null;
+        let afterEach = global.afterEach ? global.afterEach : null;
+
+        if (beforeEach && afterEach) {
+            beforeEach(async function () {
+                if (fixtureFilePath && fixtureFilePath.length) {
+                    options.saveOptions = originalSequelize.options.saveOptions;
+                    await SequelizeMocking.loadFixtureFile(truncatableSequelize, fixtureFilePath, options);
+                }
+            });
+
+            afterEach(async function () {
+                await SequelizeMocking.truncateAllTables(truncatableSequelize, options);
+            });
+        }
+    } else {
+        const beforeAll = global.beforeAll ? global.beforeAll : null;
+        const afterAll = global.afterAll ? global.afterAll : null;
+        const beforeEach = global.beforeEach ? global.beforeEach : null;
+
+        if (beforeAll && afterAll && beforeEach) {
+            let restorableSequelize = null;
+            const keepDatabaseBetweenRuns = options && options.keepDatabaseBetweenRuns;
+
+            if (keepDatabaseBetweenRuns && !options.namespace) {
+                throw new Error('got keepDatabaseBetweenRuns:true but didn\'t get a namespace. ' +
+                    'This will cause sequelizeMockingJest to create a new database every time. Please set some uniq namespace for this mock.');
+            }
+
+            const namespace = options && options.namespace ? options.namespace : uuidv4();
+
+            if (keepDatabaseBetweenRuns) {
+                console.warn(`You are running this mock with keepDatabaseBetweenRuns:true and namespace:${namespace}. This will cause sequelizeMockingJest` +
+                    ` to load the data from '.sequelize-mocking-temp/${namespace}/backup.sqlite' and ignore the mock files. Make sure to delete the '.sequelize-mocking-temp' folder` +
+                    ' after changing the mock data.');
+            }
+
+            beforeAll(async function () {
+                restorableSequelize = await SequelizeMocking.setupDatabase(originalSequelize, fixtureFilePath, options, namespace);
+            });
+
+            beforeEach(async function () {
+                restorableSequelize = await SequelizeMocking.restoreFromBackup(restorableSequelize, options, namespace);
+            });
+
+            afterAll(async function () {
+                restorableSequelize = await SequelizeMocking.cleanupDatabase(restorableSequelize, options, namespace);
+            });
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "mocking",
     "fixtures",
     "test",
-    "mocha"
+    "mocha",
+    "jest"
   ],
   "author": "Julien Roche",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Adds `sequelizeMockingJest` — a Jest-compatible wrapper for SequelizeMocking that integrates with Jest's `beforeEach`/`afterEach` lifecycle hooks
- Supports truncatable mode for efficient test database reuse and fixture loading
- Exports the new wrapper via lazy `Object.defineProperty` in `index.js`

## Test plan
- [ ] Verify `sequelizeMockingJest` can be imported from the package
- [ ] Test with Jest test suites using fixture files
- [ ] Test truncatable mode initialization and per-test truncation
- [ ] Verify existing Mocha wrapper (`sequelizeMockingMocha`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)